### PR TITLE
Simplify names

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,17 @@ We assume an inital default state of `display: none`. Therefore the above classe
 To apply different transitions for enter and leave, use `.animating-in` and `.animating-out` to declare different initial transition states. `.visible` will then include the final state for both in and out.
 
 ### Setting a state without a transition
-To skip the transitioning and force a specific display state, you may use a `force` method:
+To skip the transitioning and force a specific display state, you may pass `true` as the second parameter to `show`, `hide`, or `toggle`:
 
 ```
-$('.el').revealer('force', 'show|hide|toggle');
+$('.el').revealer('show', true);
+```
+
+### Get the current state
+To check if an element is currently visible, use the `isVisible` function:
+
+```
+var visible = $('.el').revealer('isVisible');
 ```
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -24,17 +24,17 @@ $('button.toggle').on('click', function() {
 
 Revealer doesn't actually change your element's styles--instead it adds classes in an order that allows you to transition smoothly.
 
-####`.revealer-animating` 
+####`.animating`
 Apply your initial transition state (e.g. `opacity: 0;`) as well as your `transition:` property with this class.
 
-####`.revealer-visible` 
+####`.visible`
 Apply your final transition state (e.g. `opacity: 1`) to this state.
 
 ### caveat
 We assume an inital default state of `display: none`. Therefore the above classes should also include a `display: block;` property.
 
 ### Different transitions on in and out
-To apply different transitions for enter and leave, use `.revealer-animating-in` and `.revealer-animating-out` to declare different initial transition states. `.revealer-visible` will then include the final state for both in and out.
+To apply different transitions for enter and leave, use `.animating-in` and `.animating-out` to declare different initial transition states. `.visible` will then include the final state for both in and out.
 
 ### Setting a state without a transition
 To skip the transitioning and force a specific display state, you may use a `force` method:
@@ -48,26 +48,26 @@ $('.el').revealer('force', 'show|hide|toggle');
 ```
 .element-to-reveal {
   display: none;
-  
-  &.revealer-animating,
-  &.revealer-visible {
+
+  &.animating,
+  &.visible {
     display: block;
   }
 
   // initial state for enter transition
-  &.revealer-animating-in {
+  &.animating-in {
     transform: translateX(-100%);
     transition: transform 0.3s ease;
   }
 
   // initial state for leave transition
-  &.revealer-animating-out {
+  &.animating-out {
     opacity: 0;
     transition: opacity 0.2s ease;
   }
 
   // final states for both in and out
-  &.revealer-visible {
+  &.visible {
     transform: translateX(0);
     opacity: 1;
   }

--- a/jquery.revealer.js
+++ b/jquery.revealer.js
@@ -19,20 +19,20 @@
 
   // Public API
   var methods = {
-    isOpen: function(el) {
-      return !!el.data("revealer-open");
+    isVisible: function(el) {
+      return !!el.data("revealer-visible");
     },
 
     show: function(el) {
       // Check state
-      if (methods.isOpen(el)) {
+      if (methods.isVisible(el)) {
         el.removeClass("revealer-animating revealer-animating-in");
         el.off("revealer-animating revealer-show");
         return;
       }
 
       // Remove previous event listeners
-      el.data("revealer-open", true);
+      el.data("revealer-visible", true);
       el.off("trend");
 
       raf(function(){
@@ -53,14 +53,14 @@
 
     hide: function(el) {
       // Check state
-      if (!methods.isOpen(el)) {
+      if (!methods.isVisible(el)) {
         el.removeClass("revealer-animating revealer-animating-out revealer-visible");
         el.off("revealer-animating revealer-hide");
         return;
       }
 
       // Remove previous event listeners
-      el.data("revealer-open", false);
+      el.data("revealer-visible", false);
       el.off("trend");
 
       raf(function(){
@@ -79,7 +79,7 @@
     },
 
     toggle: function(el) {
-      if (methods.isOpen(el)) {
+      if (methods.isVisible(el)) {
         methods.hide(el)
       } else {
         methods.show(el);
@@ -89,17 +89,17 @@
     // set element state without running any animations
     force: function(el, forceMethod) {
       if (forceMethod === "show") {
-        el.data("revealer-open", true);
+        el.data("revealer-visible", true);
         el.addClass("revealer-visible");
         el.trigger("revealer-show");
       } else if (forceMethod === "hide") {
-        el.data("revealer-open", false);
+        el.data("revealer-visible", false);
         el.removeClass("revealer-visible");
         el.trigger("revealer-hide");
       } else if (forceMethod === "toggle") {
-        el.data("revealer-open", !el.data("revealer-open"));
+        el.data("revealer-visible", !el.data("revealer-visible"));
         el.toggleClass("revealer-visible");
-        if (methods.isOpen(el)) {
+        if (methods.isVisible(el)) {
           el.trigger("revealer-hide");
         } else {
           el.trigger("revealer-show");
@@ -112,13 +112,12 @@
 
   // jQuery plugin
   $.fn.revealer = function(method, forceMethod) {
-
     // Get action
     var action = methods[method || "toggle"];
     if (!action) return this;
 
     // Run action
-    if (method === "isOpen") {
+    if (method === "isVisible") {
       return action(this);
     }
 

--- a/jquery.revealer.js
+++ b/jquery.revealer.js
@@ -23,7 +23,7 @@
       return !!el.data("revealer-visible");
     },
 
-    show: function(el) {
+    show: function(el, force) {
       // Check state
       if (methods.isVisible(el)) {
         el.removeClass("animating animating-in");
@@ -34,6 +34,12 @@
       // Remove previous event listeners
       el.data("revealer-visible", true);
       el.off("trend");
+
+      if (force) {
+        el.addClass("visible");
+        el.trigger("revealer-show");
+        return;
+      }
 
       raf(function(){
         // Start animation state transition
@@ -51,7 +57,7 @@
       });
     },
 
-    hide: function(el) {
+    hide: function(el, force) {
       // Check state
       if (!methods.isVisible(el)) {
         el.removeClass("animating animating-out visible");
@@ -62,6 +68,12 @@
       // Remove previous event listeners
       el.data("revealer-visible", false);
       el.off("trend");
+
+      if (force) {
+        el.removeClass("visible");
+        el.trigger("revealer-hide");
+        return;
+      }
 
       raf(function(){
         el.addClass("animating animating-out");
@@ -78,40 +90,17 @@
       });
     },
 
-    toggle: function(el) {
+    toggle: function(el, force) {
       if (methods.isVisible(el)) {
-        methods.hide(el)
+        methods.hide(el, force);
       } else {
-        methods.show(el);
-      }
-    },
-
-    // set element state without running any animations
-    force: function(el, forceMethod) {
-      if (forceMethod === "show") {
-        el.data("revealer-visible", true);
-        el.addClass("visible");
-        el.trigger("revealer-show");
-      } else if (forceMethod === "hide") {
-        el.data("revealer-visible", false);
-        el.removeClass("visible");
-        el.trigger("revealer-hide");
-      } else if (forceMethod === "toggle") {
-        el.data("revealer-visible", !el.data("revealer-visible"));
-        el.toggleClass("visible");
-        if (methods.isVisible(el)) {
-          el.trigger("revealer-hide");
-        } else {
-          el.trigger("revealer-show");
-        }
-      } else {
-        throw new Error("invalid force method.");
+        methods.show(el, force);
       }
     }
   };
 
   // jQuery plugin
-  $.fn.revealer = function(method, forceMethod) {
+  $.fn.revealer = function(method, force) {
     // Get action
     var action = methods[method || "toggle"];
     if (!action) return this;
@@ -121,18 +110,8 @@
       return action(this);
     }
 
-    if (method === "force") {
-      if (!forceMethod) {
-        throw new Error("You must declare a method when using force.");
-        return;
-      }
-      return this.each(function(){
-        action($(this), forceMethod);
-      });
-    }
-
     return this.each(function(){
-      action($(this));
+      action($(this), force);
     });
   };
 })(jQuery);

--- a/jquery.revealer.js
+++ b/jquery.revealer.js
@@ -26,7 +26,7 @@
     show: function(el) {
       // Check state
       if (methods.isVisible(el)) {
-        el.removeClass("revealer-animating revealer-animating-in");
+        el.removeClass("animating animating-in");
         el.off("revealer-animating revealer-show");
         return;
       }
@@ -37,14 +37,14 @@
 
       raf(function(){
         // Start animation state transition
-        el.addClass("revealer-animating revealer-animating-in");
+        el.addClass("animating animating-in");
         el.trigger("revealer-animating");
 
         raf(function(){
-          el.addClass("revealer-visible");
+          el.addClass("visible");
 
           el.one("trend", function(){
-            el.removeClass("revealer-animating revealer-animating-in");
+            el.removeClass("animating animating-in");
             el.trigger("revealer-show");
           });
         });
@@ -54,7 +54,7 @@
     hide: function(el) {
       // Check state
       if (!methods.isVisible(el)) {
-        el.removeClass("revealer-animating revealer-animating-out revealer-visible");
+        el.removeClass("animating animating-out visible");
         el.off("revealer-animating revealer-hide");
         return;
       }
@@ -64,14 +64,14 @@
       el.off("trend");
 
       raf(function(){
-        el.addClass("revealer-animating revealer-animating-out");
+        el.addClass("animating animating-out");
         el.trigger("revealer-animating");
 
         raf(function(){
-          el.removeClass("revealer-visible");
+          el.removeClass("visible");
 
           el.one("trend", function(){
-            el.removeClass("revealer-animating revealer-animating-in revealer-animating-out");
+            el.removeClass("animating animating-in animating-out");
             el.trigger("revealer-hide");
           });
         });
@@ -90,15 +90,15 @@
     force: function(el, forceMethod) {
       if (forceMethod === "show") {
         el.data("revealer-visible", true);
-        el.addClass("revealer-visible");
+        el.addClass("visible");
         el.trigger("revealer-show");
       } else if (forceMethod === "hide") {
         el.data("revealer-visible", false);
-        el.removeClass("revealer-visible");
+        el.removeClass("visible");
         el.trigger("revealer-hide");
       } else if (forceMethod === "toggle") {
         el.data("revealer-visible", !el.data("revealer-visible"));
-        el.toggleClass("revealer-visible");
+        el.toggleClass("visible");
         if (methods.isVisible(el)) {
           el.trigger("revealer-hide");
         } else {


### PR DESCRIPTION
A couple commits to remove the `revealer-` class prefix, change `isOpen` to `isVisible`, and make `force` a parameter to `show/hide/toggle`.
